### PR TITLE
Fix GitHub links; make social links optional

### DIFF
--- a/book/team.yaml
+++ b/book/team.yaml
@@ -57,7 +57,7 @@ people:
   social:
   - icon: github
     icon_pack: fab
-    link: aaarendt
+    link: https://github.com/aaarendt
   user_groups:
   - Lead Hackweek Organizer
 # =============
@@ -76,10 +76,6 @@ people:
   - Participatory Design and facilitation
   - Structuring productive meetings & discussions
   - Community development
-  social:
-  - icon: github
-    icon_pack: fab
-    link: ""
   user_groups:
   - Lead Community Building
 # =============
@@ -100,7 +96,7 @@ people:
   social:
   - icon: github
     icon_pack: fab
-    link: scottyhq
+    link: https://github.com/scottyhq
   user_groups:
   - Lead of Technology
   - Tutorial Lead
@@ -116,7 +112,7 @@ people:
   social:
   - icon: github
     icon_pack: fab
-    link: janekoh1
+    link: https://github.com/janekoh1
   user_groups:
   - Program Manager
 # =============
@@ -166,7 +162,7 @@ people:
   social:
   - icon: github
     icon_pack: fab
-    link: naclomi
+    link: https://github.com/naclomi
   user_groups:
   - Education Consultant
 # =============
@@ -189,7 +185,7 @@ people:
   social:
     - icon: github
       icon_pack: fab
-      link: jomey
+      link: https://github.com/jomey
   user_groups:
     - Technology Specialist
 # =============

--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -216,7 +216,7 @@
 								more &rarr;</a>
 						</div>
 						<!--//card-->
-						{%- if person['social'] %}
+						{%- if 'social' in person %}
 						<div class="card-footer text-muted">
 							<ul class="social-list list-inline mb-0">
 								{%- for social in person['social'] %}
@@ -254,15 +254,17 @@
 												<h2 class="name mb-2">{{person['title']}}</h2>
 												<div class="meta">{{ person['role'] }}</div>
 												<div class="meta mb-2">{{person['organizations']|map(attribute='name')|join(' &amp; ')}}</div>
-												<ul class="social-list list-inline mb-0">
-													{%- for social in person['social'] %}
-													<li class="list-inline-item">
-														<a href="{{social['link']}}">
-															<i class="{{social['icon_pack']}} fa-{{social['icon']}}"></i>
-														</a>
-													</li>
-													{%- endfor %}
-												</ul>
+                                                {%- if 'social' in person %}
+                                                    <ul class="social-list list-inline mb-0">
+                                                        {%- for social in person['social'] %}
+                                                        <li class="list-inline-item">
+                                                            <a href="{{social['link']}}">
+                                                                <i class="{{social['icon_pack']}} fa-{{social['icon']}}"></i>
+                                                            </a>
+                                                        </li>
+                                                        {%- endfor %}
+                                                    </ul>
+                                                {%- endif %}
 												<!--//social-list-->
 											</div>
 											<!--//col-->


### PR DESCRIPTION
Fix the links to GitHub profiles, where only names were given.
This addresses the issue for 404 errors when clicking on the social icon.

Also improve the webpage and only show social links when they are given in the yaml.