### PR TITLE
Add slippy as a valid word

### DIFF
--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -38,6 +38,7 @@ jobs:
         check_hidden: true
         only_warn: false
         skip: '*.js'
+        ignore_words_list: slippy
 
     # borrowed from https://github.com/ProjectPythia/pythia-foundations/blob/main/.github/workflows/link-checker.yaml
     - name: Disable Notebook Execution


### PR DESCRIPTION
Slippy map is a correct term in GIS. This PR adds it to the allow list so that PRs won't have the quality control check warning.

![image](https://user-images.githubusercontent.com/23487320/155600744-a50f8e2b-1d37-4c90-ad03-d00441563616.png)

Reference: https://github.com/codespell-project/actions-codespell#parameter-ignore_words_list