### PR TITLE
Fix jupyter book links to ICESat-2 hackweek's schedule and team page

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -7,9 +7,9 @@ parts:
   chapters:
     - file: application
     - title: Schedule
-      url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=schedule
+      url: https://icesat-2.hackweek.io/#schedule
     - title: Team
-      url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=team
+      url: https://icesat-2.hackweek.io/#team
     - file: mission
     - file: CoC
 - caption: Preparation

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -7,9 +7,9 @@ parts:
   chapters:
     - file: application
     - title: Schedule
-      url: https://icesat-2.hackweek.io/#schedule
+      url: https://icesat-2.hackweek.io/index.html?jump_to=schedule
     - title: Team
-      url: https://icesat-2.hackweek.io/#team
+      url: https://icesat-2.hackweek.io/index.html?jump_to=team
     - file: mission
     - file: CoC
 - caption: Preparation


### PR DESCRIPTION
Noticed that the links were pointing to https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=schedule to https://icesat-2.hackweek.io/#schedule. I also saw a few other 'uwhackweek' references (e.g in the LICENSE copyright) which I just left as is, let me know if there's any other `uwhackweek` -> 'icesat-2' changes to make :smiley: