### PR TITLE
tutorial rename to avoid naming conflict with "teamwork tutorial"

### DIFF
--- a/book/schedule.yaml
+++ b/book/schedule.yaml
@@ -75,8 +75,8 @@ tabs:
         leads: [ ]
       - time: 12:45 - 2:00
         location: Zoom
-        title: Object Oriented Programming for Collaborative Deveopment in Python
-        description: An introduction to writing well-formed modular code to fascilitate collaborative programming
+        title: Object Oriented Programming for Collaborative Development in Python
+        description: An introduction to writing well-formed modular code to facilitate collaborative programming
           - icepyx
           - working together
         leads:

--- a/book/schedule.yaml
+++ b/book/schedule.yaml
@@ -75,8 +75,8 @@ tabs:
         leads: [ ]
       - time: 12:45 - 2:00
         location: Zoom
-        title: Collaborative Deveopment
-        description: |
+        title: Object Oriented Programming for Collaborative Deveopment in Python
+        description: An introduction to writing well-formed modular code to fascilitate collaborative programming
           - icepyx
           - working together
         leads:


### PR DESCRIPTION
Better reflects OOP focus with the goal of making collaborative development easier.