### PR TITLE
Reset JupyterBook cache to speed up CI

### DIFF
--- a/.github/actions/buildresources/action.yaml
+++ b/.github/actions/buildresources/action.yaml
@@ -25,7 +25,7 @@ runs:
       with:
         path: ./book/_build
         # NOTE: change key to "jupyterbook-N-DATE"
-        key: jupyterbook-2022-03-18
+        key: jupyterbook-2022-03-21
 
     - uses: ./.github/actions/setupconda
 


### PR DESCRIPTION
Even simple updates to the website take a while to build and check currently (10+ min)
<img width="854" alt="image" src="https://user-images.githubusercontent.com/3924836/159358285-10acda4c-5099-4815-b23d-2c4e9f221f2e.png">

Our last jupyterbook cache build was last week. Unfortunately we can't just add to the cache, we have to re-build it, so currently lots of new notebooks get executed via CI even though they have not changed. This should speed up the CI workflows by a few minutes. 

https://github.com/ICESAT-2HackWeek/website2022/blob/7598db74efcc9579327f89a82de7b37b2651f313/.github/actions/buildresources/action.yaml#L28 

```
2022-03-21T20:01:55.9251371Z [01mupdating environment: [39;49;00m[01mexecuting outdated notebooks... [39;49;00mExecuting: /home/runner/work/website2022/website2022/book/tutorials/data_access/data_access_1_intro.ipynb
2022-03-21T20:01:57.3315737Z Execution Succeeded: /home/runner/work/website2022/website2022/book/tutorials/data_access/data_access_1_intro.ipynb
2022-03-21T20:01:57.3766029Z Executing: /home/runner/work/website2022/website2022/book/tutorials/data_access/data_access_3_icepyx.ipynb
2022-03-21T20:02:41.2104917Z Execution Succeeded: /home/runner/work/website2022/website2022/book/tutorials/data_access/data_access_3_icepyx.ipynb
2022-03-21T20:02:41.4818389Z Executing: /home/runner/work/website2022/website2022/book/tutorials/cloud-computing/cloud-computing-tutorial.ipynb
2022-03-21T20:03:21.3182402Z distributed.diskutils - INFO - Found stale lock file and directory '/tmp/dask/dask-worker-space/worker-mozwpsiw', purging
2022-03-21T20:03:21.3183904Z distributed.diskutils - INFO - Found stale lock file and directory '/tmp/dask/dask-worker-space/worker-j73gza40', purging
2022-03-21T20:03:21.3192313Z distributed.diskutils - INFO - Found stale lock file and directory '/tmp/dask/dask-worker-space/worker-x8m23z6j', purging
2022-03-21T20:03:21.3199173Z distributed.diskutils - INFO - Found stale lock file and directory '/tmp/dask/dask-worker-space/worker-fj9rrb8d', purging
2022-03-21T20:03:21.5122969Z Execution Succeeded: /home/runner/work/website2022/website2022/book/tutorials/cloud-computing/cloud-computing-tutorial.ipynb
2022-03-21T20:03:21.6079584Z Executing: /home/runner/work/website2022/website2022/book/tutorials/DataVisualization/dataviz2d.py
2022-03-21T20:05:44.8161941Z Execution Succeeded: /home/runner/work/website2022/website2022/book/tutorials/DataVisualization/dataviz2d.py
2022-03-21T20:05:45.1588451Z Executing: /home/runner/work/website2022/website2022/book/tutorials/data_access/data_access_2_earthdata.ipynb
2022-03-21T20:06:03.2069424Z Execution Succeeded: /home/runner/work/website2022/website2022/book/tutorials/data_access/data_access_2_earthdata.ipynb
2022-03-21T20:06:03.2482817Z done
2022-03-21T20:06:03.2486657Z [config changed ('source_suffix')] 37 added, 10 changed, 0 removed
```