### PR TITLE
Cache entire conda environment in CI

### DIFF
--- a/.github/actions/buildresources/action.yaml
+++ b/.github/actions/buildresources/action.yaml
@@ -33,6 +33,11 @@ runs:
       shell: bash -l {0}
       run: |
         ./scripts/build_resources.sh
+        
+    - name: Dump Build Logs
+      shell: bash -l {0}
+      run: |
+        cat ./book/_build/html/reports/*log 
 
     - name: Publish to GitHub Pages
       if: inputs.publish-to-gh == 'true'

--- a/.github/actions/setupconda/action.yaml
+++ b/.github/actions/setupconda/action.yaml
@@ -4,23 +4,40 @@ description: 'Create conda environment for GitHub Action Job'
 runs:
   using: "composite"
   steps:
-    - name: Setup Conda Cache
+    - name: Cache Conda Packages
+      id: cache-packages
       uses: actions/cache@v2
       env:
-        # Increase this value to reset cache if environment.yml has not changed
+        # Increase this value to reset cache if conda/conda-lock.yml has not changed
         CACHE_NUMBER: 0
       with:
         path: ~/conda_pkgs_dir
         key:
-          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/environment.yml') }}
-
-    - name: Setup Conda Environment
+          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/conda-lock.yml') }}
+    
+    - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
       with:
-        miniforge-version: latest
+        miniforge-version: 4.11.0-4
         miniforge-variant: Mambaforge
         use-mamba: true
         auto-update-conda: false
         environment-file: conda/conda-${{ runner.os == 'Linux' && 'linux' || 'osx'  }}-64.lock.yml
         activate-environment: hackweek
-        use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+        use-only-tar-bz2: true # IMPORTANT: This needs to be set for conda package cache to work properly!    
+    
+    - name: Cache Entire Conda Environment
+      id: cache-env
+      uses: actions/cache@v2
+      env:
+        CACHE_NUMBER: 0
+      with:
+        path: ${{ env.CONDA }}/envs
+        key:
+          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/conda-lock.yml') }}
+
+    - name: Update Conda Environment
+      if: steps.cache-env.outputs.cache-hit != 'true'
+      env:
+        ENVFILE: conda/conda-${{ runner.os == 'Linux' && 'linux' || 'osx'  }}-64.lock.yml
+      run: mamba env update -n hackweek -f $ENVFILE

--- a/.github/actions/setupconda/action.yaml
+++ b/.github/actions/setupconda/action.yaml
@@ -22,7 +22,6 @@ runs:
         miniforge-variant: Mambaforge
         use-mamba: true
         auto-update-conda: false
-        environment-file: conda/conda-${{ runner.os == 'Linux' && 'linux' || 'osx'  }}-64.lock.yml
         activate-environment: hackweek
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for conda package cache to work properly!    
     

--- a/.github/actions/setupconda/action.yaml
+++ b/.github/actions/setupconda/action.yaml
@@ -13,7 +13,7 @@ runs:
       with:
         path: ~/conda_pkgs_dir
         key:
-          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/conda-lock.yml') }}
+          ${{ runner.os }}-conda-packages-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/conda-lock.yml') }}
     
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
@@ -34,7 +34,7 @@ runs:
       with:
         path: ${{ env.CONDA }}/envs
         key:
-          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/conda-lock.yml') }}
+          ${{ runner.os }}-conda-environment-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/conda-lock.yml') }}
 
     - name: Update Conda Environment
       if: steps.cache-env.outputs.cache-hit != 'true'

--- a/.github/actions/setupconda/action.yaml
+++ b/.github/actions/setupconda/action.yaml
@@ -40,4 +40,5 @@ runs:
       if: steps.cache-env.outputs.cache-hit != 'true'
       env:
         ENVFILE: conda/conda-${{ runner.os == 'Linux' && 'linux' || 'osx'  }}-64.lock.yml
+      shell: bash -l {0}
       run: mamba env update -n hackweek -f $ENVFILE


### PR DESCRIPTION
Most of our current CI time is spend examining and resolving for environment compatibility, but since we use a fully resolved environment with conda-lock we can just cache the entire`/conda/envs` subfolder containing the entire environment. This should speed things up significantly (running on MacOS, environment setup is currently 12+ minutes!):
<img width="1554" alt="Screen Shot 2022-03-21 at 2 13 24 PM" src="https://user-images.githubusercontent.com/3924836/159364822-f0a6f8c4-6ee1-412a-bf15-e9e11d5286c2.png">

