### PR TITLE
Book TOC - Promote the list of projects higher up.

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -47,12 +47,12 @@ parts:
         - file: tutorials/DataVisualization/dataviz2d.py
 - caption: Projects
   chapters:
+    - file: projects/list_of_projects
     - file: projects/index
       sections:
         - file: projects/project_roles
         - file: projects/project_roadmap
         - file: projects/project_initialization
-        - file: projects/list_of_projects
 - caption: Reference
   chapters:
     - file: reference/glossary


### PR DESCRIPTION
This moves the list of 2022 projects one level up in the table of
contents. Think this makes them easier to find and promotes them a bit
better.