### PR TITLE
Schedule Day3

### DIFF
--- a/book/schedule.yaml
+++ b/book/schedule.yaml
@@ -76,6 +76,8 @@ tabs:
         leads:
           - Ben Smith
         resources:
+          - title: Slides
+            url: https://github.com/ICESAT-2HackWeek/website2022/raw/main/book/tutorials/DataProducts/ICESat-2_data_products_2022.pdf
           - title: 'Video Recording'
             url: https://youtu.be/pL9psogF_LQ
       - time: 10:00 - 10:30

--- a/book/schedule.yaml
+++ b/book/schedule.yaml
@@ -131,12 +131,19 @@ tabs:
         leads:
           - Tyler Sutterley
           - Hannah Besso
+        resources:
+          - title: 'Video Recording'
+            url: https://youtu.be/vwoR0Blynvk
       - time: 9:30 - 10:30
         location: Zoom
         title: Data Integration - Tools and Techniques
         description: In this tutorial we'll describe how to acquire other satellite and in situ data for comparison with ICESat-2.
         leads:
           - Tasha Snow
+          - Zachary Fair
+        resources:
+          - title: 'Video Recording'
+            url: https://youtu.be/HWc9FJHjQPg
       - time: 10:30 - 10:45
         title: Movement and coffee break
         description:
@@ -148,6 +155,9 @@ tabs:
         leads:
           - Philipp Arndt
           - Wei Ji Leong
+        resources:
+          - title: 'Video Recording'
+            url: https://youtu.be/fpcBFsy6Kso
       - time: 11:45 - 12:30
         title: Lunch
         description:
@@ -158,6 +168,9 @@ tabs:
         description: Helping you navigate the various sources and platforms for working with data hosted in the cloud.
         leads:
           - Aimee Barciauskas
+        resources:
+          - title: 'Video Recording'
+            url: https://youtu.be/mSklwuJ1onw
       - time: 1:30 - 2:00
         location: Zoom
         title: Detailed Dives

--- a/book/tutorials/index.md
+++ b/book/tutorials/index.md
@@ -12,12 +12,16 @@ All live tutorial recordings available via UW eScience [YouTube Playlist](https:
 
 
 | Tutorial | Topics | Recording Link |
-| -  | - | - |
+| ---  | --- | --- |
+| _Day 1_ |
 | [Open Science Tools](./jupyter.md) | Getting Started on Technology | [Recording](https://www.youtube.com/watch?v=mFaM41fRRcY) |
+| _Day 2_ |
 | [About ICESat-2 Data](./DataProducts/DataProducts.ipynb) | Standard products purpose and access |  [Recording](https://youtu.be/pL9psogF_LQ) |
 | [ICESat-2 Data Access](./data_access/data_access_1_intro.ipynb) | Programmatic and cloud access | [Recording](https://youtu.be/UpXGZLlO76w) |
 | [Object-oriented Programming](./ObjectOriented/index.md) | Modular programming for collaboration | [Recording](https://youtu.be/dhLkCX0OWYs) |
-| [Data Visualization 2D](./DataVisualization/dataviz2d.py) | Map making, PyGMT |  |
-| [Data Integration](./DataIntegration/dataintegration-1.ipynb) | pandas, xarray, dask, COGs |  |
-| [Geospatial Transforms](./geospatial/geospatial-intro.ipynb) | 2D & 3D reprojection of geospatial data with Python |  |
-| [Cloud Computing Tools](./cloud-computing/cloud-computing-tutorial.ipynb) | earthdata, rioxarray, dask |  |
+| _Day 3_ |
+| [Geospatial Transforms](./geospatial/geospatial-intro.ipynb) | 2D & 3D reprojection of geospatial data with Python | [Recording](https://youtu.be/vwoR0Blynvk) |
+| [Data Integration (Part I)](./DataIntegration/dataintegration-1.ipynb) | pandas, xarray, dask, COGs | [Recording](https://youtu.be/HWc9FJHjQPg) |
+| [Data Visualization 2D](./DataVisualization/dataviz2d.py) | Map making, PyGMT | [Recording](https://youtu.be/fpcBFsy6Kso) |
+| [Cloud Computing Tools](./cloud-computing/cloud-computing-tutorial.ipynb) | earthdata, rioxarray, dask | [Recording](https://youtu.be/mSklwuJ1onw)  |
+| |

--- a/book/tutorials/index.md
+++ b/book/tutorials/index.md
@@ -24,4 +24,5 @@ All live tutorial recordings available via UW eScience [YouTube Playlist](https:
 | [Data Integration (Part I)](./DataIntegration/dataintegration-1.ipynb) | pandas, xarray, dask, COGs | [Recording](https://youtu.be/HWc9FJHjQPg) |
 | [Data Visualization 2D](./DataVisualization/dataviz2d.py) | Map making, PyGMT | [Recording](https://youtu.be/fpcBFsy6Kso) |
 | [Cloud Computing Tools](./cloud-computing/cloud-computing-tutorial.ipynb) | earthdata, rioxarray, dask | [Recording](https://youtu.be/mSklwuJ1onw)  |
+| _Day 4_ |
 | |


### PR DESCRIPTION
Add video links for day 3

Also formatted the index for the the tutorials to add subheadings showing the days. We can remove those after the event again and I think it will help navigating/finding links during.

Lastly, added a link to Ben's slides for Day2 to the schedule.