### PR TITLE
updating earthdata access notebook to force token update

### DIFF
--- a/book/tutorials/data_access/data_access_2_earthdata.ipynb
+++ b/book/tutorials/data_access/data_access_2_earthdata.ipynb
@@ -571,7 +571,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/book/tutorials/data_access/data_access_2_earthdata.ipynb
+++ b/book/tutorials/data_access/data_access_2_earthdata.ipynb
@@ -110,6 +110,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a210a6e6-eefb-442f-bb8d-32650f8e2910",
+   "metadata": {},
+   "source": [
+    "If we need to access a dataset under an access control list (ACL) is always a good idea to refresh\n",
+    "our access tokens with CMR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e0a1571-e5c2-47e5-bd35-19c40c7147d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auth.refresh_tokens()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "26aa3967-e4dc-4429-8929-ba04be7f6a6d",
    "metadata": {
     "tags": []
@@ -471,7 +490,7 @@
     "try:\n",
     "    files = access.get(cloud_granules[0:2], \"/tmp/demo-NSIDC_CPRD/\")\n",
     "except Exception as e:\n",
-    "    print(\"If we are here maybe we are not in us-west-2 or the collection \")"
+    "    print(\"If we are here maybe we are not in us-west-2 or the collection is restricted\")"
    ]
   },
   {
@@ -552,7 +571,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - dask
   - dask-labextension
   - datashader
-  - earthdata
+  - earthdata>=0.3
   - fsspec
   - geemap
   - gh


### PR DESCRIPTION
`earthdata` is explicitly refreshing CMR tokens to avoid expiration errors in queries to restricted collections. 